### PR TITLE
[#4] update icon handling in ColorMode and LanguageToggle components

### DIFF
--- a/app/components/settings/ColorMode.vue
+++ b/app/components/settings/ColorMode.vue
@@ -47,10 +47,10 @@ const startViewTransition = (event: MouseEvent) => {
   <ClientOnly>
     <UButton
       :aria-label="`Switch to ${nextTheme} mode`"
-      :icon="nextTheme === 'dark' ? 'i-lucide-sun' : 'i-lucide-moon'"
+      :icon="`i-lucide-${nextTheme === 'dark' ? 'sun' : 'moon'}`"
       color="neutral"
       variant="ghost"
-      size="sm"
+      size="md"
       class="rounded-full"
       @click="startViewTransition"
     />

--- a/app/components/settings/LanguageToggle.vue
+++ b/app/components/settings/LanguageToggle.vue
@@ -35,7 +35,7 @@ const switchLocale = () => {
       @click="switchLocale"
     >
       <UIcon
-        :name="currentLocale?.code === 'en' ? 'i-circle-flags-en' : 'i-circle-flags-es'"
+        :name="`i-circle-flags-${currentLocale?.code}`"
       />
     </UButton>
   </ClientOnly>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,7 @@ export default defineNuxtConfig({
   modules: [
     '@nuxt/content',
     '@nuxt/ui',
+    '@nuxt/icon',
     '@nuxt/eslint',
     '@nuxt/image',
     'nuxt-og-image',
@@ -41,6 +42,10 @@ export default defineNuxtConfig({
     }
   },
   compatibilityDate: '2025-09-03',
+  icon: {
+    collections: ['lucide', 'circle-flags', 'simple-icons'],
+    provider: 'iconify'
+  },
   nitro: {
     prerender: {
       routes: [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,10 +42,6 @@ export default defineNuxtConfig({
     }
   },
   compatibilityDate: '2025-09-03',
-  icon: {
-    collections: ['lucide', 'circle-flags', 'simple-icons'],
-    provider: 'iconify'
-  },
   nitro: {
     prerender: {
       routes: [
@@ -61,5 +57,9 @@ export default defineNuxtConfig({
     ],
     defaultLocale: 'en',
     strategy: 'prefix_except_default'
+  },
+  icon: {
+    collections: ['lucide', 'circle-flags', 'simple-icons'],
+    provider: 'iconify'
   }
 })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "typecheck": "nuxt typecheck"
   },
   "dependencies": {
+    "@iconify-json/circle-flags": "^1.2.8",
+    "@iconify-json/lucide": "^1.2.64",
+    "@iconify-json/simple-icons": "^1.2.49",
     "@nuxt/content": "^3.6.3",
+    "@nuxt/icon": "^1.7.2",
     "@nuxt/image": "1.11.0",
     "@nuxt/ui": "4.0.0",
     "@nuxtjs/i18n": "^10.0.6",
@@ -29,9 +33,6 @@
     "vue": "^3.5.21"
   },
   "devDependencies": {
-    "@iconify-json/circle-flags": "^1.2.8",
-    "@iconify-json/lucide": "^1.2.64",
-    "@iconify-json/simple-icons": "^1.2.49",
     "@nuxt/eslint": "1.9.0",
     "@types/node": "24.3.0",
     "eslint": "^9.34.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,21 @@ importers:
 
   .:
     dependencies:
+      '@iconify-json/circle-flags':
+        specifier: ^1.2.8
+        version: 1.2.8
+      '@iconify-json/lucide':
+        specifier: ^1.2.64
+        version: 1.2.66
+      '@iconify-json/simple-icons':
+        specifier: ^1.2.49
+        version: 1.2.50
       '@nuxt/content':
         specifier: ^3.6.3
         version: 3.6.3(better-sqlite3@12.2.0)(magicast@0.3.5)
+      '@nuxt/icon':
+        specifier: ^1.7.2
+        version: 1.15.0(magicast@0.3.5)(vite@7.1.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))
       '@nuxt/image':
         specifier: 1.11.0
         version: 1.11.0(db0@0.3.2(better-sqlite3@12.2.0))(ioredis@5.7.0)(magicast@0.3.5)
@@ -51,15 +63,6 @@ importers:
         specifier: ^3.5.21
         version: 3.5.21(typescript@5.9.2)
     devDependencies:
-      '@iconify-json/circle-flags':
-        specifier: ^1.2.8
-        version: 1.2.8
-      '@iconify-json/lucide':
-        specifier: ^1.2.64
-        version: 1.2.66
-      '@iconify-json/simple-icons':
-        specifier: ^1.2.49
-        version: 1.2.50
       '@nuxt/eslint':
         specifier: 1.9.0
         version: 1.9.0(@typescript-eslint/utils@8.42.0(eslint@9.34.0(jiti@2.5.1))(typescript@5.9.2))(@vue/compiler-sfc@3.5.21)(eslint@9.34.0(jiti@2.5.1))(magicast@0.3.5)(typescript@5.9.2)(vite@7.1.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
@@ -113,6 +116,9 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@antfu/utils@8.1.1':
+    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
   '@antfu/utils@9.2.1':
     resolution: {integrity: sha512-TMilPqXyii1AsiEii6l6ubRzbo76p6oshUSYPaKsmXDavyMLqjzVDkcp3pHp5ELMUNJHATcEOGxKTTsX9yYhGg==}
@@ -685,6 +691,9 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@iconify/utils@2.3.0':
+    resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
+
   '@iconify/utils@3.0.2':
     resolution: {integrity: sha512-EfJS0rLfVuRuJRn4psJHtK2A9TqVnkxPpHY6lYHiB9+8eSuudsxbwMiavocG45ujOo6FJ+CIRlRnlOGinzkaGQ==}
 
@@ -926,6 +935,9 @@ packages:
 
   '@nuxt/fonts@0.11.4':
     resolution: {integrity: sha512-GbLavsC+9FejVwY+KU4/wonJsKhcwOZx/eo4EuV57C4osnF/AtEmev8xqI0DNlebMEhEGZbu1MGwDDDYbeR7Bw==}
+
+  '@nuxt/icon@1.15.0':
+    resolution: {integrity: sha512-kA0rxqr1B601zNJNcOXera8CyYcxUCEcT7dXEC7rwAz71PRCN5emf7G656eKEQgtqrD4JSj6NQqWDgrmFcf/GQ==}
 
   '@nuxt/icon@2.0.0':
     resolution: {integrity: sha512-sy8+zkKMYp+H09S0cuTteL3zPTmktqzYPpPXV9ZkLNjrQsaPH08n7s/9wjr+C/K/w2R3u18E3+P1VIQi3xaq1A==}
@@ -6137,6 +6149,8 @@ snapshots:
       package-manager-detector: 1.3.0
       tinyexec: 1.0.1
 
+  '@antfu/utils@8.1.1': {}
+
   '@antfu/utils@9.2.1': {}
 
   '@apidevtools/json-schema-ref-parser@11.9.3':
@@ -6645,6 +6659,19 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@iconify/utils@2.3.0':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@antfu/utils': 8.1.1
+      '@iconify/types': 2.0.0
+      debug: 4.4.3
+      globals: 15.15.0
+      kolorist: 1.8.0
+      local-pkg: 1.1.2
+      mlly: 1.8.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@iconify/utils@3.0.2':
     dependencies:
       '@antfu/install-pkg': 1.1.0
@@ -7128,6 +7155,28 @@ snapshots:
       - magicast
       - uploadthing
       - vite
+
+  '@nuxt/icon@1.15.0(magicast@0.3.5)(vite@7.1.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
+    dependencies:
+      '@iconify/collections': 1.0.599
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.3.0
+      '@iconify/vue': 5.0.0(vue@3.5.21(typescript@5.9.2))
+      '@nuxt/devtools-kit': 2.6.5(magicast@0.3.5)(vite@7.1.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      '@nuxt/kit': 3.19.2(magicast@0.3.5)
+      consola: 3.4.2
+      local-pkg: 1.1.2
+      mlly: 1.8.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinyglobby: 0.2.15
+    transitivePeerDependencies:
+      - magicast
+      - supports-color
+      - vite
+      - vue
 
   '@nuxt/icon@2.0.0(magicast@0.3.5)(vite@7.1.4(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))(vue@3.5.21(typescript@5.9.2))':
     dependencies:


### PR DESCRIPTION
This pull request adds support for the Nuxt Icon module and improves the way icons are handled throughout the app. The main changes include installing necessary icon packages, configuring icon collections and provider, and simplifying icon usage in UI components to use dynamic names.

**Icon support and configuration:**

* Added `@nuxt/icon` module and icon packages (`@iconify-json/circle-flags`, `@iconify-json/lucide`, `@iconify-json/simple-icons`) to dependencies in `package.json` and removed them from `devDependencies` to ensure proper runtime usage. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17-R21) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L32-L34)
* Registered the Nuxt Icon module in `nuxt.config.ts` and configured it to use the specified icon collections with the `iconify` provider. [[1]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R5) [[2]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R45-R48)

**UI component improvements:**

* Updated the icon binding in `ColorMode.vue` to use a dynamic icon name based on the theme, and adjusted the button size from `sm` to `md` for better visibility.
* Simplified the locale icon selection in `LanguageToggle.vue` to use a dynamic icon name based on the current locale code.